### PR TITLE
Add note to use absolute paths when running the script

### DIFF
--- a/build-kernel
+++ b/build-kernel
@@ -25,7 +25,7 @@
 # Install postmarketOS user space on the phone as described at
 # https://wiki.postmarketos.org/wiki/Google_Nexus_5_(lg-hammerhead)
 #
-# Build and boot the upstream kernel:
+# Build and boot the upstream kernel (Use absolute paths!):
 #
 #   ~/src/nexus-5-upstream/build-kernel ~/src/linux
 #   sudo fastboot boot ~/src/linux/arch/arm/boot/nexus5-boot.img


### PR DESCRIPTION
Passing the parameters for the script as relative paths doesn't work. I tried making it work by reverting the `cd`s after they were done, with `cd -`, but I still faced other problems.

For the time being though, I think it would already help prevent this issue to warn the user to use absolute paths in the instructions for running the script.