### PR TITLE
Add baud rate to UART cable instructions

### DIFF
--- a/UART_CABLE.md
+++ b/UART_CABLE.md
@@ -77,7 +77,7 @@ over the serial cable:
     [2270] -- portchange --
     [2360] fastboot: processing commands
 
-You can use the minicom package to access the serial console. Here's my ~/.minirc.dfl file:
+You can use the minicom package to access the serial console. The baud rate should be 115200. Here's my ~/.minirc.dfl file:
 
     pu port             /dev/ttyUSB0
     pu rtscts           No


### PR DESCRIPTION
Add the default baud rate value of 115200 to the instructions on booting the phone with the UART cable.

Even though this value can be changed, it is the default one used by the `build-kernel` script and also when installing postmarketOS, so should make it easier for newcomers.