### PR TITLE
Update rear flashlight information in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,9 +18,9 @@ have any updates to this list. Feel free to pick up an item on this list if you'
 - GPS - Patch for gpsd is in [this tree](https://github.com/andersson/gpsd/commits/master) for the
   Qualcomm PDS service support. Start gpsd with `sudo gpsd -N -D9 -F /var/run/gpsd.sock` and
   connect to it with `sudo gpsdctl add pds://any`, and test with `sudo gpsmon`.
-- The rear flashlight is supported in the downstream Linux kernel with the
-  [drivers/leds/leds-qpnp.c](https://github.com/AICP/kernel_lge_hammerhead/blob/n7.1/drivers/leds/leds-qpnp.c)
-  driver and referred to as torch in that code. Likely requires a new driver upstream.
+- Rear flashlight - [Nícolas](https://github.com/nfraprado) is currently working on upstreaming the driver.
+  There is an [RFC PATCH](https://lore.kernel.org/linux-arm-msm/20201106165737.1029106-1-nfraprado@protonmail.com/T/#md240cd09d8860b9eb1dcf641366a454d14a73c02)
+  that already works but still needs a lot of clean up.
 - The front LED appears to be supported by an out-of-tree patch with the
   [Qualcomm Light Pulse Generator (LPG) driver](https://lkml.org/lkml/2017/11/15/26).
 - Battery - Appears to be supported by the


### PR DESCRIPTION
Update the TODO page to reflect the fact that I'm working on the rear flashlight and have an RFC patch going that already works. This way anyone interested can just see the latest patch instead of redoing the work.