### PR TITLE
Update Battery as supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ onto newer upstream LTS kernel releases.
 
 The following components work upstream without any additional patches: display, backlight,
 touchscreen, USB, WiFi, charger, gyroscope / accelerometer, magnetometer,
-temperature / humidity / barometer, proximity / ambient light sensor (ALS), serial console.
+temperature / humidity / barometer, proximity / ambient light sensor (ALS), serial console, battery.
 
 My [linux tree on GitHub](https://github.com/masneyb/linux) contains work-in-progress patches
 that adds support for the GPU, modem, bluetooth, and vibrator. See my

--- a/TODO.md
+++ b/TODO.md
@@ -23,10 +23,6 @@ have any updates to this list. Feel free to pick up an item on this list if you'
   that already works but still needs a lot of clean up.
 - The front LED appears to be supported by an out-of-tree patch with the
   [Qualcomm Light Pulse Generator (LPG) driver](https://lkml.org/lkml/2017/11/15/26).
-- Battery - Appears to be supported by the
-  [Maxim ModelGauge ICs gauge driver](https://lore.kernel.org/patchwork/patch/437579/). Look at the
-  [PM8941 Battery Monitoring System](https://lore.kernel.org/lkml/20180614151435.6471-2-ctatlor97@gmail.com/)
-  as well.
 - CPUFreq support for msm8974. See [this message](https://lore.kernel.org/lkml/20190812152826.GA7958@centauri/)
   for more details. The referenced patch in linux-next is titled
   'cpufreq: qcom: Re-organise kryo cpufreq to use it for other nvmem based qcom socs'.


### PR DESCRIPTION
Starting with 5.11-rc1, the battery is supported:
https://lore.kernel.org/lkml/20200922114237.1803628-1-iskren.chernev@gmail.com/
https://lore.kernel.org/lkml/20201126141144.1763779-2-iskren.chernev@gmail.com/

Feel free to only accept this when 5.11 lands though.